### PR TITLE
Additional /help option to instead display the ship database commands

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,1 @@
+- Remove comments on the DB commands when ready to submit pull request

--- a/TODO
+++ b/TODO
@@ -1,1 +1,0 @@
-- Remove comments on the DB commands when ready to submit pull request

--- a/bot.py
+++ b/bot.py
@@ -15,13 +15,15 @@ import traceback
 
 from datetime import datetime as dt
 
-#load_dotenv()
+load_dotenv()
+
+TOKEN = os.getenv('DISCORD_TOKEN')
 
 API_URL = "https://cosmo-api-six.vercel.app/"
 API_NEW = "https://api.cosmoship.duckdns.org/"
 
-db = fight_db.FightDB(db_name="/home/astrod/Desktop/Bots/cosmoteer-com/test.db")
-#db = fight_db.FightDB()
+# db = fight_db.FightDB(db_name="/home/astrod/Desktop/Bots/cosmoteer-com/test.db")
+# #db = fight_db.FightDB()
 
 
 intents = discord.Intents.default()
@@ -331,53 +333,53 @@ async def help(interaction: discord.Interaction):
     await interaction.followup.send(help_text, file=discord.File("legend.png"))
     print(dt.now(),"help command sent")
 
-@tree.command(name="elim ship rock-paper-scissors", description='play rock-paper-scissors, but with elimination archtypes!')
-async def rps(player_pick):
-    ships={"cannon wall":{"wins":["avoider"]},
-           "avoider"    :{"wins":["dc spinner"]},
-           "dc spinner" :{"wins":["cannon wall"]}
-    }
+# @tree.command(name="elim_ship_rock-paper-scissors", description='play rock-paper-scissors, but with elimination archtypes!')
+# async def rps(interaction: discord.Interaction, player_pick):
+#     ships={"cannon wall":{"wins":["avoider"]},
+#            "avoider"    :{"wins":["dc spinner"]},
+#            "dc spinner" :{"wins":["cannon wall"]}
+#     }
 
-    player_pick=player_pick.lower().strip()
-    computer_pick = random.choice(list(ships.keys()))
+#     player_pick=player_pick.lower().strip()
+#     computer_pick = random.choice(list(ships.keys()))
 
-    if(player_pick not in ships):
-        await interaction.response.send_message(f"Error:{player_pick} You need to pick between "+', '.join(list(ships.keys())))
-        return
-    player_win=False
-    computer_win=False
-    if(computer_pick in ships[player_pick]["wins"]):
-        player_win=True
-    elif(player_pick in ships[computer_pick]["wins"]):
-        computer_win=True
-
-
-    if player_win == True: # Display results to user
-        await interaction.response.send_message(f"{interaction.user.display_name} picked `{player_pick}` and Cosmoteer Design Tools picked `{computer_pick}`; {interaction.user.display_name} wins!")
-    elif computer_win:
-        await interaction.response.send_message(f"{interaction.user.display_name} picked `{player_pick}` and Cosmoteer Design Tools picked `{computer_pick}`; Cosmoteer Design Tools wins!")
-    else:
-        await interaction.response.send_message(f"{interaction.user.display_name} and Cosmoteer Design Tools picked `{player_pick}`; it is a draw!")
-
-@tree.command(name="db_add_fight", description='adds a new fight to the database')
-async def db_add_fight(interaction: discord.Interaction, shipname1: str, shipname2: str, result: str):
-    shipname1=shipname1.lower().strip()
-    shipname2=shipname2.lower().strip()
-    result=result.lower().strip()
-    if result=="win" or result=="w":
-        result=fight_db.FIGHT_RESULT.WIN
-    elif result=="lose" or result=="l":
-        result=fight_db.FIGHT_RESULT.WIN
-        temp=shipname1
-        shipname1=shipname2
-        shipname2=temp
-    elif result=="draw" or result=="d":
-        result=fight_db.FIGHT_RESULT.DRAW
-    else:
-        print(f"Both player and Cosmoteer Design Tools picked {player_pick}; it is a draw!")
+#     if(player_pick not in ships):
+#         await interaction.response.send_message(f"Error:{player_pick} You need to pick between "+', '.join(list(ships.keys())))
+#         return
+#     player_win=False
+#     computer_win=False
+#     if(computer_pick in ships[player_pick]["wins"]):
+#         player_win=True
+#     elif(player_pick in ships[computer_pick]["wins"]):
+#         computer_win=True
 
 
-rps("dc spinner         ")
+#     if player_win == True: # Display results to user
+#         await interaction.response.send_message(f"{interaction.user.display_name} picked `{player_pick}` and Cosmoteer Design Tools picked `{computer_pick}`; {interaction.user.display_name} wins!")
+#     elif computer_win:
+#         await interaction.response.send_message(f"{interaction.user.display_name} picked `{player_pick}` and Cosmoteer Design Tools picked `{computer_pick}`; Cosmoteer Design Tools wins!")
+#     else:
+#         await interaction.response.send_message(f"{interaction.user.display_name} and Cosmoteer Design Tools picked `{player_pick}`; it is a draw!")
+
+# @tree.command(name="db_add_fight", description='adds a new fight to the database')
+# async def db_add_fight(interaction: discord.Interaction, shipname1: str, shipname2: str, result: str):
+#     shipname1=shipname1.lower().strip()
+#     shipname2=shipname2.lower().strip()
+#     result=result.lower().strip()
+#     if result=="win" or result=="w":
+#         result=fight_db.FIGHT_RESULT.WIN
+#     elif result=="lose" or result=="l":
+#         result=fight_db.FIGHT_RESULT.WIN
+#         temp=shipname1
+#         shipname1=shipname2
+#         shipname2=temp
+#     elif result=="draw" or result=="d":
+#         result=fight_db.FIGHT_RESULT.DRAW
+#     else:
+#         print(f"Both player and Cosmoteer Design Tools picked {player_pick}; it is a draw!")
+
+
+# rps("dc spinner         ")
 
 #client.run(os.getenv("DISCORDBOTAPI"))
-client.run(secret_token.token)
+client.run(TOKEN)

--- a/bot.py
+++ b/bot.py
@@ -2,7 +2,7 @@ import discord
 from discord import app_commands
 import secret_token
 
-# import fight_db
+import fight_db
 
 import base64
 from io import BytesIO
@@ -13,25 +13,13 @@ import traceback
 
 from datetime import datetime as dt
 
-import os #REMOVE THESE LINES BEFORE SUBMITTING PULL REQUEST
-from dotenv import load_dotenv
-load_dotenv()
-TOKEN = os.getenv('DISCORD_TOKEN')
 
 API_URL = "https://cosmo-api-six.vercel.app/"
 API_NEW = "https://api.cosmoship.duckdns.org/"
 
-# UNCOMMENT EACH OF THE DB COMMANDS BEFORE SUBMITTING PULL REQUEST
-
-# BOT_PATH = "/home/astrod/Desktop/Bots/cosmoteer-com/"
-BOT_PATH = "/Users/nirav/Documents/GitHub/cosmoteer-com/" # for the love of god please remove this one especially
-# db = fight_db.FightDB(db_name=BOT_PATH+"test.db")
-# #db = fight_db.FightDB()
-
-# BOT_PATH = "/home/astrod/Desktop/Bots/cosmoteer-com/"
-# db = fight_db.FightDB(db_name=BOT_PATH+"test.db")
-#db = fight_db.FightDB()
-
+BOT_PATH = "/home/astrod/Desktop/Bots/cosmoteer-com/"
+db = fight_db.FightDB(db_name=BOT_PATH+"test.db")
+db = fight_db.FightDB()
 
 
 intents = discord.Intents.default()
@@ -401,186 +389,186 @@ async def rps(interaction: discord.Interaction, player_pick: str):
     else:
         await interaction.response.send_message(f"{interaction.user.display_name} and Cosmoteer Design Tools picked `{player_pick}`; it is a draw!")
 
-# @tree.command(name="db_add_fight", description='adds a new fight to the database')
-# async def db_add_fight(interaction: discord.Interaction, shipname1: str, shipname2: str, result: str):
-#     shipname1=shipname1.lower().strip()
-#     shipname2=shipname2.lower().strip()
-#     result=result.lower().strip()
-#     if result=="win" or result=="w":
-#         result=fight_db.FIGHT_RESULT.WIN
-#     elif result=="lose" or result=="l":
-#         result=fight_db.FIGHT_RESULT.WIN
-#         temp=shipname1
-#         shipname1=shipname2
-#         shipname2=temp
-#     elif result=="draw" or result=="d":
-#         result=fight_db.FIGHT_RESULT.DRAW
-#     else:
-#         await interaction.response.send_message(f"Error: result must be 'win', 'lose' or 'draw'")
-#         return
+@tree.command(name="db_add_fight", description='adds a new fight to the database')
+async def db_add_fight(interaction: discord.Interaction, shipname1: str, shipname2: str, result: str):
+    shipname1=shipname1.lower().strip()
+    shipname2=shipname2.lower().strip()
+    result=result.lower().strip()
+    if result=="win" or result=="w":
+        result=fight_db.FIGHT_RESULT.WIN
+    elif result=="lose" or result=="l":
+        result=fight_db.FIGHT_RESULT.WIN
+        temp=shipname1
+        shipname1=shipname2
+        shipname2=temp
+    elif result=="draw" or result=="d":
+        result=fight_db.FIGHT_RESULT.DRAW
+    else:
+        await interaction.response.send_message(f"Error: result must be 'win', 'lose' or 'draw'")
+        return
 
-#     author=str(interaction.user.id)
-#     author_name=interaction.user.display_name
-#     try:
-#         db.insert_fight(shipname1, shipname2, author, author_name, result)
-#         winner_text=""
-#         if result==fight_db.FIGHT_RESULT.WIN:
-#             winner_text="the winner is "+shipname1
-#         elif result==fight_db.FIGHT_RESULT.DRAW:
-#             winner_text="it is a draw"
-#         await interaction.response.send_message(f"In a fight between {shipname1} and {shipname2}, {winner_text}, according to {author_name}")
-#     except Exception as e:
-#         await interaction.response.send_message(f"Error:{e}")
-#         return
+    author=str(interaction.user.id)
+    author_name=interaction.user.display_name
+    try:
+        db.insert_fight(shipname1, shipname2, author, author_name, result)
+        winner_text=""
+        if result==fight_db.FIGHT_RESULT.WIN:
+            winner_text="the winner is "+shipname1
+        elif result==fight_db.FIGHT_RESULT.DRAW:
+            winner_text="it is a draw"
+        await interaction.response.send_message(f"In a fight between {shipname1} and {shipname2}, {winner_text}, according to {author_name}")
+    except Exception as e:
+        await interaction.response.send_message(f"Error:{e}")
+        return
     
-# @tree.command(name="db_add_ship", description='adds a new ship to the database')
-# async def db_add_ship(interaction: discord.Interaction, shipname: str):
-#     shipname=shipname.lower().strip()
-#     author=str(interaction.user.id)
-#     author_name=interaction.user.display_name
-#     try:
-#         db.add_ship(shipname, author, author_name)
-#         await interaction.response.send_message(f"Ship {shipname} added to the database")
-#     except Exception as e:
-#         await interaction.response.send_message(f"Error:{e}")
-#         return
+@tree.command(name="db_add_ship", description='adds a new ship to the database')
+async def db_add_ship(interaction: discord.Interaction, shipname: str):
+    shipname=shipname.lower().strip()
+    author=str(interaction.user.id)
+    author_name=interaction.user.display_name
+    try:
+        db.add_ship(shipname, author, author_name)
+        await interaction.response.send_message(f"Ship {shipname} added to the database")
+    except Exception as e:
+        await interaction.response.send_message(f"Error:{e}")
+        return
     
-# @tree.command(name="db_remove_fight", description='removes a fight from the database')
-# async def db_remove_fight(interaction: discord.Interaction, shipname1: str, shipname2: str):
-#     shipname1=shipname1.lower().strip()
-#     shipname2=shipname2.lower().strip()
-#     author=str(interaction.user.id)
-#     try:
-#         db.remove_fight(shipname1, shipname2, author)
-#         await interaction.response.send_message(f"Fight between {shipname1} and {shipname2} removed from the database")
-#     except Exception as e:
-#         await interaction.response.send_message(f"Error:{e}")
-#         return
+@tree.command(name="db_remove_fight", description='removes a fight from the database')
+async def db_remove_fight(interaction: discord.Interaction, shipname1: str, shipname2: str):
+    shipname1=shipname1.lower().strip()
+    shipname2=shipname2.lower().strip()
+    author=str(interaction.user.id)
+    try:
+        db.remove_fight(shipname1, shipname2, author)
+        await interaction.response.send_message(f"Fight between {shipname1} and {shipname2} removed from the database")
+    except Exception as e:
+        await interaction.response.send_message(f"Error:{e}")
+        return
     
-# @tree.command(name="db_get_matchups", description='gets the matchups of a ship from the database')
-# async def db_get_matchups(interaction: discord.Interaction, shipname: str):
-#     shipname=shipname.lower().strip()
-#     try:
-#         wins, draws, losses=db.get_matchups(shipname)
-#         text_wins="Wins:\n"
-#         for ship in wins:
-#             text_wins+=f"- **{ship}** : {', '.join(wins[ship])}\n"
-#         text_draws="Draws:\n"
-#         for ship in draws:
-#             text_draws+=f"- **{ship}** : {', '.join(draws[ship])}\n"
-#         text_losses="Losses:\n"
-#         for ship in losses:
-#             text_losses+=f"- **{ship}** : {', '.join(losses[ship])}\n"
-#         text=f"Matchups for **{shipname}**\n"+text_wins+"\n"+text_draws+"\n"+text_losses
-#         await interaction.response.send_message(text)
-#     except Exception as e:
-#         await interaction.response.send_message(f"Error:{str(traceback.format_exception_only(type(e), e)[0])}")
-#         return
+@tree.command(name="db_get_matchups", description='gets the matchups of a ship from the database')
+async def db_get_matchups(interaction: discord.Interaction, shipname: str):
+    shipname=shipname.lower().strip()
+    try:
+        wins, draws, losses=db.get_matchups(shipname)
+        text_wins="Wins:\n"
+        for ship in wins:
+            text_wins+=f"- **{ship}** : {', '.join(wins[ship])}\n"
+        text_draws="Draws:\n"
+        for ship in draws:
+            text_draws+=f"- **{ship}** : {', '.join(draws[ship])}\n"
+        text_losses="Losses:\n"
+        for ship in losses:
+            text_losses+=f"- **{ship}** : {', '.join(losses[ship])}\n"
+        text=f"Matchups for **{shipname}**\n"+text_wins+"\n"+text_draws+"\n"+text_losses
+        await interaction.response.send_message(text)
+    except Exception as e:
+        await interaction.response.send_message(f"Error:{str(traceback.format_exception_only(type(e), e)[0])}")
+        return
 
     
-# @tree.command(name="db_simulate_fight", description='simulates a fight between two ships')
-# async def db_simulate_fight(interaction: discord.Interaction, shipname1: str, shipname2: str):
-#     shipname1=shipname1.lower().strip()
-#     shipname2=shipname2.lower().strip()
-#     try:
-#         result=db.simulate_fight(shipname1, shipname2)
-#         people_win=result.get(fight_db.FIGHT_RESULT.WIN)
-#         if people_win==None:
-#             people_win=[]
-#         people_draw=result.get(fight_db.FIGHT_RESULT.DRAW)
-#         if people_draw==None:
-#             people_draw=[]
-#         people_lose=result.get(fight_db.FIGHT_RESULT.LOSE)
-#         if people_lose==None:
-#             people_lose=[]
-#         text=f"In a fight between {shipname1} and {shipname2}, the results are:\n {len(people_win)} people think {shipname1} would win\n {len(people_draw)} people think it would be a draw\n {len(people_lose)} people think {shipname2} would win"
-#         await interaction.response.send_message(text)
-#     except Exception as e:
-#         await interaction.response.send_message(f"Error:{e}")
-#         return
+@tree.command(name="db_simulate_fight", description='simulates a fight between two ships')
+async def db_simulate_fight(interaction: discord.Interaction, shipname1: str, shipname2: str):
+    shipname1=shipname1.lower().strip()
+    shipname2=shipname2.lower().strip()
+    try:
+        result=db.simulate_fight(shipname1, shipname2)
+        people_win=result.get(fight_db.FIGHT_RESULT.WIN)
+        if people_win==None:
+            people_win=[]
+        people_draw=result.get(fight_db.FIGHT_RESULT.DRAW)
+        if people_draw==None:
+            people_draw=[]
+        people_lose=result.get(fight_db.FIGHT_RESULT.LOSE)
+        if people_lose==None:
+            people_lose=[]
+        text=f"In a fight between {shipname1} and {shipname2}, the results are:\n {len(people_win)} people think {shipname1} would win\n {len(people_draw)} people think it would be a draw\n {len(people_lose)} people think {shipname2} would win"
+        await interaction.response.send_message(text)
+    except Exception as e:
+        await interaction.response.send_message(f"Error:{e}")
+        return
 
-# @tree.command(name="db_list_ships", description='lists all ships in the database')
-# async def db_list_ships(interaction: discord.Interaction):
-#     try:
-#         ships=db.get_ships()
-#         #sort the ships
-#         ships.sort()
-#         text="Ships in the database:\n"
-#         for ship in ships:
-#             text+=f"- {ship}\n"
-#         await interaction.response.send_message(text)
-#     except Exception as e:
-#         await interaction.response.send_message(f"Error:{e}")
-#         return
+@tree.command(name="db_list_ships", description='lists all ships in the database')
+async def db_list_ships(interaction: discord.Interaction):
+    try:
+        ships=db.get_ships()
+        #sort the ships
+        ships.sort()
+        text="Ships in the database:\n"
+        for ship in ships:
+            text+=f"- {ship}\n"
+        await interaction.response.send_message(text)
+    except Exception as e:
+        await interaction.response.send_message(f"Error:{e}")
+        return
     
-# @tree.command(name="db_get_unknown_matchups", description='gets the unknown matchups of a ship from the database')
-# async def db_get_unknown_matchups(interaction: discord.Interaction, shipname: str):
-#     shipname=shipname.lower().strip()
-#     try:
-#         ships=db.get_unknown_matchups(shipname)
-#         text="Unknown matchups for "+shipname+":\n"
-#         for ship in ships:
-#             text+=f"- {ship}\n"
-#         await interaction.response.send_message(text)
-#     except Exception as e:
-#         await interaction.response.send_message(f"Error:{e}")
-#         return
+@tree.command(name="db_get_unknown_matchups", description='gets the unknown matchups of a ship from the database')
+async def db_get_unknown_matchups(interaction: discord.Interaction, shipname: str):
+    shipname=shipname.lower().strip()
+    try:
+        ships=db.get_unknown_matchups(shipname)
+        text="Unknown matchups for "+shipname+":\n"
+        for ship in ships:
+            text+=f"- {ship}\n"
+        await interaction.response.send_message(text)
+    except Exception as e:
+        await interaction.response.send_message(f"Error:{e}")
+        return
 
-# @tree.command(name="db_export_csv", description='exports the database to a csv file')
-# async def db_export_csv(interaction: discord.Interaction):
-#     try:
-#         db.export_csv("fight_database.csv")
-#         # Create a file object for the CSV file
-#         csv_file = discord.File("fight_database.csv", filename="fight_database.csv")
-#         # Send the CSV file to the user
-#         await interaction.response.send_message("Database exported to CSV file", file=csv_file)
-#     except Exception as e:
-#         await interaction.response.send_message(f"Error:{e}")
-#         return
+@tree.command(name="db_export_csv", description='exports the database to a csv file')
+async def db_export_csv(interaction: discord.Interaction):
+    try:
+        db.export_csv("fight_database.csv")
+        # Create a file object for the CSV file
+        csv_file = discord.File("fight_database.csv", filename="fight_database.csv")
+        # Send the CSV file to the user
+        await interaction.response.send_message("Database exported to CSV file", file=csv_file)
+    except Exception as e:
+        await interaction.response.send_message(f"Error:{e}")
+        return
     
-# @tree.command(name="db_export_db", description='exports the database to a db file')
-# async def db_export_db(interaction: discord.Interaction):
-#     try:
-#         db.export_db("fight_database.db")
-#         # Create a file object for the DB file
-#         db_file = discord.File("fight_database.db", filename="fight_database.db")
-#         # Send the DB file to the user
-#         await interaction.response.send_message("Database exported to DB file", file=db_file)
-#     except Exception as e:
-#         await interaction.response.send_message(f"Error:{e}")
-#         return
+@tree.command(name="db_export_db", description='exports the database to a db file')
+async def db_export_db(interaction: discord.Interaction):
+    try:
+        db.export_db("fight_database.db")
+        # Create a file object for the DB file
+        db_file = discord.File("fight_database.db", filename="fight_database.db")
+        # Send the DB file to the user
+        await interaction.response.send_message("Database exported to DB file", file=db_file)
+    except Exception as e:
+        await interaction.response.send_message(f"Error:{e}")
+        return
     
-# @tree.command(name="db_rename_ship", description='renames a ship in the database')
-# async def db_rename_ship(interaction: discord.Interaction, old_name: str, new_name: str):
-#     old_name=old_name.lower().strip()
-#     new_name=new_name.lower().strip()
-#     try:
-#         author=str(interaction.user.id)
-#         if author!="457210821773361152":
-#             raise ValueError("Only LunastroD can rename ships!")
-#         db.rename_ship(old_name, new_name)
-#         await interaction.response.send_message(f"Ship {old_name} renamed to {new_name}")
-#     except Exception as e:
-#         await interaction.response.send_message(f"Error:{e}")
-#         return
+@tree.command(name="db_rename_ship", description='renames a ship in the database')
+async def db_rename_ship(interaction: discord.Interaction, old_name: str, new_name: str):
+    old_name=old_name.lower().strip()
+    new_name=new_name.lower().strip()
+    try:
+        author=str(interaction.user.id)
+        if author!="457210821773361152":
+            raise ValueError("Only LunastroD can rename ships!")
+        db.rename_ship(old_name, new_name)
+        await interaction.response.send_message(f"Ship {old_name} renamed to {new_name}")
+    except Exception as e:
+        await interaction.response.send_message(f"Error:{e}")
+        return
     
-# @tree.command(name="db_scoreboard", description='shows the scoreboard of the database')
-# async def db_scoreboard(interaction: discord.Interaction):
-#     try:
-#         ships=db.get_ships()
-#         scoreboard={}
-#         for s in ships:
-#             wins, draws, losses=db.get_matchups(s)
-#             scoreboard[s]=[len(wins), len(draws), len(losses), len(wins)+len(draws)+len(losses)]
-#         #sort the ships by number of wins
-#         ships.sort(key=lambda x: scoreboard[x][0], reverse=True)
-#         table = "Scoreboard             |Win|Draw|Lost|Total\n"
-#         for ship in ships:
-#             table += f"{ship.ljust(23)}|{str(scoreboard[ship][0]).ljust(3)}|{str(scoreboard[ship][1]).ljust(4)}|{str(scoreboard[ship][2]).ljust(4)}|{str(scoreboard[ship][3])}\n"
-#         await interaction.response.send_message(f"```{table}```")
-#     except Exception as e:
-#         await interaction.response.send_message(f"Error:{e}")
-#         return
+@tree.command(name="db_scoreboard", description='shows the scoreboard of the database')
+async def db_scoreboard(interaction: discord.Interaction):
+    try:
+        ships=db.get_ships()
+        scoreboard={}
+        for s in ships:
+            wins, draws, losses=db.get_matchups(s)
+            scoreboard[s]=[len(wins), len(draws), len(losses), len(wins)+len(draws)+len(losses)]
+        #sort the ships by number of wins
+        ships.sort(key=lambda x: scoreboard[x][0], reverse=True)
+        table = "Scoreboard             |Win|Draw|Lost|Total\n"
+        for ship in ships:
+            table += f"{ship.ljust(23)}|{str(scoreboard[ship][0]).ljust(3)}|{str(scoreboard[ship][1]).ljust(4)}|{str(scoreboard[ship][2]).ljust(4)}|{str(scoreboard[ship][3])}\n"
+        await interaction.response.send_message(f"```{table}```")
+    except Exception as e:
+        await interaction.response.send_message(f"Error:{e}")
+        return
 
 # #client.run(os.getenv("DISCORDBOTAPI"))
-client.run(TOKEN) # secret_token.token
+client.run(secret_token.token)

--- a/bot.py
+++ b/bot.py
@@ -29,7 +29,7 @@ BOT_PATH = "/Users/nirav/Documents/GitHub/cosmoteer-com" # for the love of god p
 # #db = fight_db.FightDB()
 
 # BOT_PATH = "/home/astrod/Desktop/Bots/cosmoteer-com/"
-db = fight_db.FightDB(db_name=BOT_PATH+"test.db")
+# db = fight_db.FightDB(db_name=BOT_PATH+"test.db")
 #db = fight_db.FightDB()
 
 
@@ -570,23 +570,23 @@ async def rps(interaction: discord.Interaction, player_pick: str):
 #         await interaction.response.send_message(f"Error:{e}")
 #         return
     
-@tree.command(name="db_scoreboard", description='shows the scoreboard of the database')
-async def db_scoreboard(interaction: discord.Interaction):
-    try:
-        ships=db.get_ships()
-        scoreboard={}
-        for s in ships:
-            wins, draws, losses=db.get_matchups(s)
-            scoreboard[s]=[len(wins), len(draws), len(losses), len(wins)+len(draws)+len(losses)]
-        #sort the ships by number of wins
-        ships.sort(key=lambda x: scoreboard[x][0], reverse=True)
-        table = "Scoreboard             |Win|Draw|Lost|Total\n"
-        for ship in ships:
-            table += f"{ship.ljust(23)}|{str(scoreboard[ship][0]).ljust(3)}|{str(scoreboard[ship][1]).ljust(4)}|{str(scoreboard[ship][2]).ljust(4)}|{str(scoreboard[ship][3])}\n"
-        await interaction.response.send_message(f"```{table}```")
-    except Exception as e:
-        await interaction.response.send_message(f"Error:{e}")
-        return
+# @tree.command(name="db_scoreboard", description='shows the scoreboard of the database')
+# async def db_scoreboard(interaction: discord.Interaction):
+#     try:
+#         ships=db.get_ships()
+#         scoreboard={}
+#         for s in ships:
+#             wins, draws, losses=db.get_matchups(s)
+#             scoreboard[s]=[len(wins), len(draws), len(losses), len(wins)+len(draws)+len(losses)]
+#         #sort the ships by number of wins
+#         ships.sort(key=lambda x: scoreboard[x][0], reverse=True)
+#         table = "Scoreboard             |Win|Draw|Lost|Total\n"
+#         for ship in ships:
+#             table += f"{ship.ljust(23)}|{str(scoreboard[ship][0]).ljust(3)}|{str(scoreboard[ship][1]).ljust(4)}|{str(scoreboard[ship][2]).ljust(4)}|{str(scoreboard[ship][3])}\n"
+#         await interaction.response.send_message(f"```{table}```")
+#     except Exception as e:
+#         await interaction.response.send_message(f"Error:{e}")
+#         return
 
 # #client.run(os.getenv("DISCORDBOTAPI"))
 client.run(TOKEN) # secret_token.token

--- a/bot.py
+++ b/bot.py
@@ -24,7 +24,7 @@ API_NEW = "https://api.cosmoship.duckdns.org/"
 # UNCOMMENT EACH OF THE DB COMMANDS BEFORE SUBMITTING PULL REQUEST
 
 # BOT_PATH = "/home/astrod/Desktop/Bots/cosmoteer-com/"
-BOT_PATH = "/Users/nirav/Documents/GitHub/cosmoteer-com" # for the love of god please remove this one especially
+BOT_PATH = "/Users/nirav/Documents/GitHub/cosmoteer-com/" # for the love of god please remove this one especially
 # db = fight_db.FightDB(db_name=BOT_PATH+"test.db")
 # #db = fight_db.FightDB()
 
@@ -60,32 +60,32 @@ the bot considers the lateral thrust of each thruster
 the bot doesn't work with modded parts
 """
 
-db_help_text = f"""/version: """+version_text+"""
+db_help_text = f""+version_text+"""
 
 The Cosmoteer Design Tools bot has a database of every known multiplayer elimination archetype and their matchups that can be contributed to by anybody.
 Below is a list of commands that are used to access and contribute to the database.
 
-/help: Shows this message
+**/help:** Shows this message
 
-/db_list_ships: Lists every single ship type in the bot's archetype database. A handy reference for other db commands.
+**/db_list_ships:** Lists every single ship type in the bot's archetype database. A handy reference for other db commands.
 
-/db_add_ships: Adds a new ship to the database.
+**/db_add_ships:** Adds a new ship to the database.
 
-/db_rename_ship: Changes the existing name of a ship to a different specified one.
+**/db_rename_ship:** Changes the existing name of a ship to a different specified one. Only LunastroD can use this command.
 
-/db_scoreboard: Shows the win/loss/draw ratio for each ship in the database based on matchups.
+**/db_scoreboard:** Shows the win/loss/draw ratio for each ship in the database based on matchups.
 
-/db_get_matchups: Lists each matchup (win, loss, draw) of a specified ship from the database.
+**/db_get_matchups:** Lists each matchup (win, loss, draw) of a specified ship from the database.
 
-/db_get_unknown_matchups: Lists each matchup that has no votes from a specified ship from the database.
+**/db_get_unknown_matchups:** Lists each matchup that has no votes from a specified ship from the database.
 
-/db_add_fight: Add a new matchup between 2 specified ship in the database.
+**/db_add_fight:** Add a new matchup between 2 specified ship in the database.
 
-/db_remove_fight: Removes a matchup between 2 specified ship in the database.
+**/db_remove_fight:** Removes a matchup between 2 specified ship in the database.
 
-/db_simulate_fight: Simulates a fight between 2 specified ship, based on the listed matchup in the database.
+**/db_simulate_fight:** Simulates a fight between 2 specified ship, based on the listed matchup in the database.
 
-/db_export_csv: Exports the entire database to a .csv file.
+**/db_export_csv:** Exports the entire database to a .csv file.
 """
 
 @client.event
@@ -349,7 +349,7 @@ async def ping(interaction: discord.Interaction):
         await interaction.response.send_message("hmmm")
 
 @tree.command(name="help", description="shows the list of commands")
-async def help(interaction: discord.Interaction):
+async def help(interaction: discord.Interaction, show_db_commands: bool = True):
     """
     Responds to a help command and sends a list of commands.
 
@@ -359,25 +359,19 @@ async def help(interaction: discord.Interaction):
     Returns:
         None
     """
-    print(dt.now(),"help command received")
-    # Defer the initial response to prevent timeouts
-    try:
-        await interaction.response.defer()
-        
-        # Send the help text along with the legend image as a file
-        await interaction.followup.send(help_text, file=discord.File(BOT_PATH+"legend.png"))
-    except Exception as e:
-        print(dt.now(),"Error:",e)
-        await interaction.followup.send("Error:"+str(e))
-    try:
-        await interaction.response.defer()
-        
-        # Send the help text along with the legend image as a file
-        await interaction.followup.send(help_text, file=discord.File(BOT_PATH+"legend.png"))
-    except Exception as e:
-        print(dt.now(),"Error:",e)
-        await interaction.followup.send("Error:"+str(e))
-    print(dt.now(),"help command sent")
+    if show_db_commands == False:
+        print(dt.now(),"help command received")
+        # Defer the initial response to prevent timeouts
+        try:
+            await interaction.response.defer()
+            
+            # Send the help text along with the legend image as a file
+            await interaction.followup.send(help_text, file=discord.File(BOT_PATH+"legend.png"))
+        except Exception as e:
+            print(dt.now(),"Error:",e)
+            await interaction.followup.send("Error:"+str(e))
+    else:
+            await interaction.response.send_message(db_help_text)
 
 @tree.command(name="elim_rps", description='play rock-paper-scissors, but with elimination archtypes!')
 async def rps(interaction: discord.Interaction, player_pick: str):

--- a/bot.py
+++ b/bot.py
@@ -2,7 +2,7 @@ import discord
 from discord import app_commands
 import secret_token
 
-import fight_db
+# import fight_db
 
 import base64
 from io import BytesIO
@@ -13,11 +13,15 @@ import traceback
 
 from datetime import datetime as dt
 
+import os #REMOVE THESE LINES BEFORE SUBMITTING PULL REQUEST
+from dotenv import load_dotenv
+load_dotenv()
+TOKEN = os.getenv('DISCORD_TOKEN')
 
 API_URL = "https://cosmo-api-six.vercel.app/"
 API_NEW = "https://api.cosmoship.duckdns.org/"
 
-db = fight_db.FightDB(db_name="/home/astrod/Desktop/Bots/cosmoteer-com/test.db")
+# db = fight_db.FightDB(db_name="/home/astrod/Desktop/Bots/cosmoteer-com/test.db")
 #db = fight_db.FightDB()
 
 
@@ -357,174 +361,174 @@ async def rps(interaction: discord.Interaction, player_pick: str):
     else:
         await interaction.response.send_message(f"{interaction.user.display_name} and Cosmoteer Design Tools picked `{player_pick}`; it is a draw!")
 
-@tree.command(name="db_add_fight", description='adds a new fight to the database')
-async def db_add_fight(interaction: discord.Interaction, shipname1: str, shipname2: str, result: str):
-    shipname1=shipname1.lower().strip()
-    shipname2=shipname2.lower().strip()
-    result=result.lower().strip()
-    if result=="win" or result=="w":
-        result=fight_db.FIGHT_RESULT.WIN
-    elif result=="lose" or result=="l":
-        result=fight_db.FIGHT_RESULT.WIN
-        temp=shipname1
-        shipname1=shipname2
-        shipname2=temp
-    elif result=="draw" or result=="d":
-        result=fight_db.FIGHT_RESULT.DRAW
-    else:
-        await interaction.response.send_message(f"Error: result must be 'win', 'lose' or 'draw'")
-        return
+# @tree.command(name="db_add_fight", description='adds a new fight to the database')
+# async def db_add_fight(interaction: discord.Interaction, shipname1: str, shipname2: str, result: str):
+#     shipname1=shipname1.lower().strip()
+#     shipname2=shipname2.lower().strip()
+#     result=result.lower().strip()
+#     if result=="win" or result=="w":
+#         result=fight_db.FIGHT_RESULT.WIN
+#     elif result=="lose" or result=="l":
+#         result=fight_db.FIGHT_RESULT.WIN
+#         temp=shipname1
+#         shipname1=shipname2
+#         shipname2=temp
+#     elif result=="draw" or result=="d":
+#         result=fight_db.FIGHT_RESULT.DRAW
+#     else:
+#         await interaction.response.send_message(f"Error: result must be 'win', 'lose' or 'draw'")
+#         return
 
-    author=str(interaction.user.id)
-    author_name=interaction.user.display_name
-    try:
-        db.insert_fight(shipname1, shipname2, author, author_name, result)
-        winner_text=""
-        if result==fight_db.FIGHT_RESULT.WIN:
-            winner_text="the winner is "+shipname1
-        elif result==fight_db.FIGHT_RESULT.DRAW:
-            winner_text="it is a draw"
-        await interaction.response.send_message(f"In a fight between {shipname1} and {shipname2}, {winner_text}, according to {author_name}")
-    except Exception as e:
-        await interaction.response.send_message(f"Error:{e}")
-        return
+#     author=str(interaction.user.id)
+#     author_name=interaction.user.display_name
+#     try:
+#         db.insert_fight(shipname1, shipname2, author, author_name, result)
+#         winner_text=""
+#         if result==fight_db.FIGHT_RESULT.WIN:
+#             winner_text="the winner is "+shipname1
+#         elif result==fight_db.FIGHT_RESULT.DRAW:
+#             winner_text="it is a draw"
+#         await interaction.response.send_message(f"In a fight between {shipname1} and {shipname2}, {winner_text}, according to {author_name}")
+#     except Exception as e:
+#         await interaction.response.send_message(f"Error:{e}")
+#         return
     
-@tree.command(name="db_add_ship", description='adds a new ship to the database')
-async def db_add_ship(interaction: discord.Interaction, shipname: str):
-    shipname=shipname.lower().strip()
-    author=str(interaction.user.id)
-    author_name=interaction.user.display_name
-    try:
-        db.add_ship(shipname, author, author_name)
-        await interaction.response.send_message(f"Ship {shipname} added to the database")
-    except Exception as e:
-        await interaction.response.send_message(f"Error:{e}")
-        return
+# @tree.command(name="db_add_ship", description='adds a new ship to the database')
+# async def db_add_ship(interaction: discord.Interaction, shipname: str):
+#     shipname=shipname.lower().strip()
+#     author=str(interaction.user.id)
+#     author_name=interaction.user.display_name
+#     try:
+#         db.add_ship(shipname, author, author_name)
+#         await interaction.response.send_message(f"Ship {shipname} added to the database")
+#     except Exception as e:
+#         await interaction.response.send_message(f"Error:{e}")
+#         return
     
-@tree.command(name="db_remove_fight", description='removes a fight from the database')
-async def db_remove_fight(interaction: discord.Interaction, shipname1: str, shipname2: str):
-    shipname1=shipname1.lower().strip()
-    shipname2=shipname2.lower().strip()
-    author=str(interaction.user.id)
-    try:
-        db.remove_fight(shipname1, shipname2, author)
-        await interaction.response.send_message(f"Fight between {shipname1} and {shipname2} removed from the database")
-    except Exception as e:
-        await interaction.response.send_message(f"Error:{e}")
-        return
+# @tree.command(name="db_remove_fight", description='removes a fight from the database')
+# async def db_remove_fight(interaction: discord.Interaction, shipname1: str, shipname2: str):
+#     shipname1=shipname1.lower().strip()
+#     shipname2=shipname2.lower().strip()
+#     author=str(interaction.user.id)
+#     try:
+#         db.remove_fight(shipname1, shipname2, author)
+#         await interaction.response.send_message(f"Fight between {shipname1} and {shipname2} removed from the database")
+#     except Exception as e:
+#         await interaction.response.send_message(f"Error:{e}")
+#         return
     
-@tree.command(name="db_get_matchups", description='gets the matchups of a ship from the database')
-async def db_get_matchups(interaction: discord.Interaction, shipname: str):
-    shipname=shipname.lower().strip()
-    try:
-        wins, draws, losses=db.get_matchups(shipname)
-        text_wins="Wins:\n"
-        for ship in wins:
-            text_wins+=f"- **{ship}** : {', '.join(wins[ship])}\n"
-        text_draws="Draws:\n"
-        for ship in draws:
-            text_draws+=f"- **{ship}** : {', '.join(draws[ship])}\n"
-        text_losses="Losses:\n"
-        for ship in losses:
-            text_losses+=f"- **{ship}** : {', '.join(losses[ship])}\n"
-        text=f"Matchups for **{shipname}**\n"+text_wins+"\n"+text_draws+"\n"+text_losses
-        await interaction.response.send_message(text)
-    except Exception as e:
-        await interaction.response.send_message(f"Error:{str(traceback.format_exception_only(type(e), e)[0])}")
-        return
+# @tree.command(name="db_get_matchups", description='gets the matchups of a ship from the database')
+# async def db_get_matchups(interaction: discord.Interaction, shipname: str):
+#     shipname=shipname.lower().strip()
+#     try:
+#         wins, draws, losses=db.get_matchups(shipname)
+#         text_wins="Wins:\n"
+#         for ship in wins:
+#             text_wins+=f"- **{ship}** : {', '.join(wins[ship])}\n"
+#         text_draws="Draws:\n"
+#         for ship in draws:
+#             text_draws+=f"- **{ship}** : {', '.join(draws[ship])}\n"
+#         text_losses="Losses:\n"
+#         for ship in losses:
+#             text_losses+=f"- **{ship}** : {', '.join(losses[ship])}\n"
+#         text=f"Matchups for **{shipname}**\n"+text_wins+"\n"+text_draws+"\n"+text_losses
+#         await interaction.response.send_message(text)
+#     except Exception as e:
+#         await interaction.response.send_message(f"Error:{str(traceback.format_exception_only(type(e), e)[0])}")
+#         return
 
     
-@tree.command(name="db_simulate_fight", description='simulates a fight between two ships')
-async def db_simulate_fight(interaction: discord.Interaction, shipname1: str, shipname2: str):
-    shipname1=shipname1.lower().strip()
-    shipname2=shipname2.lower().strip()
-    try:
-        result=db.simulate_fight(shipname1, shipname2)
-        people_win=result.get(fight_db.FIGHT_RESULT.WIN)
-        if people_win==None:
-            people_win=[]
-        people_draw=result.get(fight_db.FIGHT_RESULT.DRAW)
-        if people_draw==None:
-            people_draw=[]
-        people_lose=result.get(fight_db.FIGHT_RESULT.LOSE)
-        if people_lose==None:
-            people_lose=[]
-        text=f"In a fight between {shipname1} and {shipname2}, the results are:\n {len(people_win)} people think {shipname1} would win\n {len(people_draw)} people think it would be a draw\n {len(people_lose)} people think {shipname2} would win"
-        await interaction.response.send_message(text)
-    except Exception as e:
-        await interaction.response.send_message(f"Error:{e}")
-        return
+# @tree.command(name="db_simulate_fight", description='simulates a fight between two ships')
+# async def db_simulate_fight(interaction: discord.Interaction, shipname1: str, shipname2: str):
+#     shipname1=shipname1.lower().strip()
+#     shipname2=shipname2.lower().strip()
+#     try:
+#         result=db.simulate_fight(shipname1, shipname2)
+#         people_win=result.get(fight_db.FIGHT_RESULT.WIN)
+#         if people_win==None:
+#             people_win=[]
+#         people_draw=result.get(fight_db.FIGHT_RESULT.DRAW)
+#         if people_draw==None:
+#             people_draw=[]
+#         people_lose=result.get(fight_db.FIGHT_RESULT.LOSE)
+#         if people_lose==None:
+#             people_lose=[]
+#         text=f"In a fight between {shipname1} and {shipname2}, the results are:\n {len(people_win)} people think {shipname1} would win\n {len(people_draw)} people think it would be a draw\n {len(people_lose)} people think {shipname2} would win"
+#         await interaction.response.send_message(text)
+#     except Exception as e:
+#         await interaction.response.send_message(f"Error:{e}")
+#         return
 
-@tree.command(name="db_list_ships", description='lists all ships in the database')
-async def db_list_ships(interaction: discord.Interaction):
-    try:
-        ships=db.get_ships()
-        #sort the ships
-        ships.sort()
-        text="Ships in the database:\n"
-        for ship in ships:
-            text+=f"- {ship}\n"
-        await interaction.response.send_message(text)
-    except Exception as e:
-        await interaction.response.send_message(f"Error:{e}")
-        return
+# @tree.command(name="db_list_ships", description='lists all ships in the database')
+# async def db_list_ships(interaction: discord.Interaction):
+#     try:
+#         ships=db.get_ships()
+#         #sort the ships
+#         ships.sort()
+#         text="Ships in the database:\n"
+#         for ship in ships:
+#             text+=f"- {ship}\n"
+#         await interaction.response.send_message(text)
+#     except Exception as e:
+#         await interaction.response.send_message(f"Error:{e}")
+#         return
     
-@tree.command(name="db_get_unknown_matchups", description='gets the unknown matchups of a ship from the database')
-async def db_get_unknown_matchups(interaction: discord.Interaction, shipname: str):
-    shipname=shipname.lower().strip()
-    try:
-        ships=db.get_unknown_matchups(shipname)
-        text="Unknown matchups for "+shipname+":\n"
-        for ship in ships:
-            text+=f"- {ship}\n"
-        await interaction.response.send_message(text)
-    except Exception as e:
-        await interaction.response.send_message(f"Error:{e}")
-        return
+# @tree.command(name="db_get_unknown_matchups", description='gets the unknown matchups of a ship from the database')
+# async def db_get_unknown_matchups(interaction: discord.Interaction, shipname: str):
+#     shipname=shipname.lower().strip()
+#     try:
+#         ships=db.get_unknown_matchups(shipname)
+#         text="Unknown matchups for "+shipname+":\n"
+#         for ship in ships:
+#             text+=f"- {ship}\n"
+#         await interaction.response.send_message(text)
+#     except Exception as e:
+#         await interaction.response.send_message(f"Error:{e}")
+#         return
 
-@tree.command(name="db_export_csv", description='exports the database to a csv file')
-async def db_export_csv(interaction: discord.Interaction):
-    try:
-        db.export_csv("fight_database.csv")
-        # Create a file object for the CSV file
-        csv_file = discord.File("fight_database.csv", filename="fight_database.csv")
-        # Send the CSV file to the user
-        await interaction.response.send_message("Database exported to CSV file", file=csv_file)
-    except Exception as e:
-        await interaction.response.send_message(f"Error:{e}")
-        return
+# @tree.command(name="db_export_csv", description='exports the database to a csv file')
+# async def db_export_csv(interaction: discord.Interaction):
+#     try:
+#         db.export_csv("fight_database.csv")
+#         # Create a file object for the CSV file
+#         csv_file = discord.File("fight_database.csv", filename="fight_database.csv")
+#         # Send the CSV file to the user
+#         await interaction.response.send_message("Database exported to CSV file", file=csv_file)
+#     except Exception as e:
+#         await interaction.response.send_message(f"Error:{e}")
+#         return
     
-@tree.command(name="db_rename_ship", description='renames a ship in the database')
-async def db_rename_ship(interaction: discord.Interaction, old_name: str, new_name: str):
-    old_name=old_name.lower().strip()
-    new_name=new_name.lower().strip()
-    try:
-        author=str(interaction.user.id)
-        if author!="457210821773361152":
-            raise ValueError("Only LunastroD can rename ships!")
-        db.rename_ship(old_name, new_name)
-        await interaction.response.send_message(f"Ship {old_name} renamed to {new_name}")
-    except Exception as e:
-        await interaction.response.send_message(f"Error:{e}")
-        return
+# @tree.command(name="db_rename_ship", description='renames a ship in the database')
+# async def db_rename_ship(interaction: discord.Interaction, old_name: str, new_name: str):
+#     old_name=old_name.lower().strip()
+#     new_name=new_name.lower().strip()
+#     try:
+#         author=str(interaction.user.id)
+#         if author!="457210821773361152":
+#             raise ValueError("Only LunastroD can rename ships!")
+#         db.rename_ship(old_name, new_name)
+#         await interaction.response.send_message(f"Ship {old_name} renamed to {new_name}")
+#     except Exception as e:
+#         await interaction.response.send_message(f"Error:{e}")
+#         return
     
-@tree.command(name="db_scoreboard", description='shows the scoreboard of the database')
-async def db_scoreboard(interaction: discord.Interaction):
-    try:
-        ships=db.get_ships()
-        scoreboard={}
-        for s in ships:
-            wins, draws, losses=db.get_matchups(s)
-            scoreboard[s]=[len(wins), len(draws), len(losses), len(wins)+len(draws)+len(losses)]
-        #sort the ships by number of wins
-        ships.sort(key=lambda x: scoreboard[x][0], reverse=True)
-        text="Scoreboard:\n"
-        for ship in ships:
-            text+=f"- **{ship}**: {scoreboard[ship][0]} {round(100*scoreboard[ship][0]/scoreboard[ship][3])}% win {scoreboard[ship][1]} {round(100*scoreboard[ship][1]/scoreboard[ship][3])}% draw {scoreboard[ship][2]} {round(100*scoreboard[ship][2]/scoreboard[ship][3])}% loss {scoreboard[ship][3]} total\n"
-        await interaction.response.send_message(text)
-    except Exception as e:
-        await interaction.response.send_message(f"Error:{e}")
-        return
+# @tree.command(name="db_scoreboard", description='shows the scoreboard of the database')
+# async def db_scoreboard(interaction: discord.Interaction):
+#     try:
+#         ships=db.get_ships()
+#         scoreboard={}
+#         for s in ships:
+#             wins, draws, losses=db.get_matchups(s)
+#             scoreboard[s]=[len(wins), len(draws), len(losses), len(wins)+len(draws)+len(losses)]
+#         #sort the ships by number of wins
+#         ships.sort(key=lambda x: scoreboard[x][0], reverse=True)
+#         text="Scoreboard:\n"
+#         for ship in ships:
+#             text+=f"- **{ship}**: {scoreboard[ship][0]} {round(100*scoreboard[ship][0]/scoreboard[ship][3])}% win {scoreboard[ship][1]} {round(100*scoreboard[ship][1]/scoreboard[ship][3])}% draw {scoreboard[ship][2]} {round(100*scoreboard[ship][2]/scoreboard[ship][3])}% loss {scoreboard[ship][3]} total\n"
+#         await interaction.response.send_message(text)
+#     except Exception as e:
+#         await interaction.response.send_message(f"Error:{e}")
+#         return
 
-#client.run(os.getenv("DISCORDBOTAPI"))
-client.run(secret_token.token)
+# #client.run(os.getenv("DISCORDBOTAPI"))
+client.run(TOKEN) # secret_token.token

--- a/bot.py
+++ b/bot.py
@@ -1,9 +1,9 @@
-import discord
+import discord #TODO: generate new key lmao
 from discord import app_commands
 import secret_token
 
-#from dotenv import load_dotenv
-#import os
+from dotenv import load_dotenv
+import os
 #import center_of_mass
 
 import base64
@@ -14,7 +14,9 @@ import random
 
 from datetime import datetime as dt
 
-#load_dotenv()
+load_dotenv()
+TOKEN = os.getenv("DISCORD_TOKEN")
+GUILD = os.getenv("DISCORD_GUILD")
 
 API_URL = "https://cosmo-api-six.vercel.app/analyze"
 API_URL2 = "https://api.cosmoship.duckdns.org/analyze"
@@ -66,7 +68,6 @@ async def on_ready():
     
     # Print a message indicating that the bot is ready
     print(dt.now(),"Bot is ready")
-
 
 @tree.command(name="com", description="Calculates the center of mass of a cosmoteer ship.png")
 async def com(interaction: discord.Interaction, ship: discord.Attachment, boost: bool = True, flip_vectors: bool = False, draw_all_cot: bool = True, draw_all_com: bool = False):
@@ -329,7 +330,7 @@ async def help(interaction: discord.Interaction):
     await interaction.followup.send(help_text, file=discord.File("legend.png"))
     print(dt.now(),"help command sent")
 
-@tree.command(name="elim ship rock-paper-scissors", description='play rock-paper-scissors, but with elimination archtypes!')
+@tree.command(name="elim_ship_rock-paper-scissors", description='play rock-paper-scissors, but with elimination archtypes!')
 async def rps(player_pick):
     ships={"cannon wall":{"wins":["avoider"]},
            "avoider"    :{"wins":["dc spinner"]},
@@ -359,7 +360,7 @@ async def rps(player_pick):
         print(f"Both player and Cosmoteer Design Tools picked {player_pick}; it is a draw!")
 
 
-rps("dc spinner         ")
+# rps("dc spinner         ")
 
 #client.run(os.getenv("DISCORDBOTAPI"))
-client.run(secret_token.token)
+client.run(TOKEN)

--- a/bot.py
+++ b/bot.py
@@ -21,6 +21,7 @@ TOKEN = os.getenv('DISCORD_TOKEN')
 API_URL = "https://cosmo-api-six.vercel.app/"
 API_NEW = "https://api.cosmoship.duckdns.org/"
 
+# UNCOMMENT EACH OF THE DB COMMANDS BEFORE SUBMITTING PULL REQUEST
 # db = fight_db.FightDB(db_name="/home/astrod/Desktop/Bots/cosmoteer-com/test.db")
 #db = fight_db.FightDB()
 
@@ -498,6 +499,18 @@ async def rps(interaction: discord.Interaction, player_pick: str):
 #         await interaction.response.send_message(f"Error:{e}")
 #         return
     
+# @tree.command(name="db_export_db", description='exports the database to a db file')
+# async def db_export_db(interaction: discord.Interaction):
+#     try:
+#         db.export_db("fight_database.db")
+#         # Create a file object for the DB file
+#         db_file = discord.File("fight_database.db", filename="fight_database.db")
+#         # Send the DB file to the user
+#         await interaction.response.send_message("Database exported to DB file", file=db_file)
+#     except Exception as e:
+#         await interaction.response.send_message(f"Error:{e}")
+#         return
+    
 # @tree.command(name="db_rename_ship", description='renames a ship in the database')
 # async def db_rename_ship(interaction: discord.Interaction, old_name: str, new_name: str):
 #     old_name=old_name.lower().strip()
@@ -522,10 +535,10 @@ async def rps(interaction: discord.Interaction, player_pick: str):
 #             scoreboard[s]=[len(wins), len(draws), len(losses), len(wins)+len(draws)+len(losses)]
 #         #sort the ships by number of wins
 #         ships.sort(key=lambda x: scoreboard[x][0], reverse=True)
-#         text="Scoreboard:\n"
+#         table = "Scoreboard               |Wins  |Draws |Losses|Total\n"
 #         for ship in ships:
-#             text+=f"- **{ship}**: {scoreboard[ship][0]} {round(100*scoreboard[ship][0]/scoreboard[ship][3])}% win {scoreboard[ship][1]} {round(100*scoreboard[ship][1]/scoreboard[ship][3])}% draw {scoreboard[ship][2]} {round(100*scoreboard[ship][2]/scoreboard[ship][3])}% loss {scoreboard[ship][3]} total\n"
-#         await interaction.response.send_message(text)
+#             table += f"{ship.ljust(25)}|{str(scoreboard[ship][0]).ljust(6)}|{str(scoreboard[ship][1]).ljust(6)}|{str(scoreboard[ship][2]).ljust(6)}|{str(scoreboard[ship][3])}\n"
+#         await interaction.response.send_message(f"```{table}```")
 #     except Exception as e:
 #         await interaction.response.send_message(f"Error:{e}")
 #         return

--- a/bot.py
+++ b/bot.py
@@ -1,10 +1,8 @@
-import discord #TODO: generate new key lmao
+import discord
 from discord import app_commands
 import secret_token
 
-from dotenv import load_dotenv
-import os
-#import center_of_mass
+import fight_db
 
 import base64
 from io import BytesIO
@@ -15,15 +13,12 @@ import traceback
 
 from datetime import datetime as dt
 
-load_dotenv()
-
-TOKEN = os.getenv('DISCORD_TOKEN')
 
 API_URL = "https://cosmo-api-six.vercel.app/"
 API_NEW = "https://api.cosmoship.duckdns.org/"
 
-# db = fight_db.FightDB(db_name="/home/astrod/Desktop/Bots/cosmoteer-com/test.db")
-# #db = fight_db.FightDB()
+db = fight_db.FightDB(db_name="/home/astrod/Desktop/Bots/cosmoteer-com/test.db")
+#db = fight_db.FightDB()
 
 
 intents = discord.Intents.default()
@@ -73,6 +68,7 @@ async def on_ready():
     
     # Print a message indicating that the bot is ready
     print(dt.now(),"Bot is ready")
+
 
 @tree.command(name="com", description="Calculates the center of mass of a cosmoteer ship.png")
 async def com(interaction: discord.Interaction, ship: discord.Attachment, boost: bool = True, flip_vectors: bool = False, draw_all_cot: bool = True, draw_all_com: bool = False):
@@ -333,53 +329,202 @@ async def help(interaction: discord.Interaction):
     await interaction.followup.send(help_text, file=discord.File("legend.png"))
     print(dt.now(),"help command sent")
 
-# @tree.command(name="elim_ship_rock-paper-scissors", description='play rock-paper-scissors, but with elimination archtypes!')
-# async def rps(interaction: discord.Interaction, player_pick):
-#     ships={"cannon wall":{"wins":["avoider"]},
-#            "avoider"    :{"wins":["dc spinner"]},
-#            "dc spinner" :{"wins":["cannon wall"]}
-#     }
+@tree.command(name="elim_rps", description='play rock-paper-scissors, but with elimination archtypes!')
+async def rps(interaction: discord.Interaction, player_pick: str):
+    ships={"cannon wall":{"wins":["avoider"]},
+           "avoider"    :{"wins":["dc spinner"]},
+           "dc spinner" :{"wins":["cannon wall"]}
+    }
 
-#     player_pick=player_pick.lower().strip()
-#     computer_pick = random.choice(list(ships.keys()))
+    player_pick=player_pick.lower().strip()
+    computer_pick = random.choice(list(ships.keys()))
 
-#     if(player_pick not in ships):
-#         await interaction.response.send_message(f"Error:{player_pick} You need to pick between "+', '.join(list(ships.keys())))
-#         return
-#     player_win=False
-#     computer_win=False
-#     if(computer_pick in ships[player_pick]["wins"]):
-#         player_win=True
-#     elif(player_pick in ships[computer_pick]["wins"]):
-#         computer_win=True
-
-
-#     if player_win == True: # Display results to user
-#         await interaction.response.send_message(f"{interaction.user.display_name} picked `{player_pick}` and Cosmoteer Design Tools picked `{computer_pick}`; {interaction.user.display_name} wins!")
-#     elif computer_win:
-#         await interaction.response.send_message(f"{interaction.user.display_name} picked `{player_pick}` and Cosmoteer Design Tools picked `{computer_pick}`; Cosmoteer Design Tools wins!")
-#     else:
-#         await interaction.response.send_message(f"{interaction.user.display_name} and Cosmoteer Design Tools picked `{player_pick}`; it is a draw!")
-
-# @tree.command(name="db_add_fight", description='adds a new fight to the database')
-# async def db_add_fight(interaction: discord.Interaction, shipname1: str, shipname2: str, result: str):
-#     shipname1=shipname1.lower().strip()
-#     shipname2=shipname2.lower().strip()
-#     result=result.lower().strip()
-#     if result=="win" or result=="w":
-#         result=fight_db.FIGHT_RESULT.WIN
-#     elif result=="lose" or result=="l":
-#         result=fight_db.FIGHT_RESULT.WIN
-#         temp=shipname1
-#         shipname1=shipname2
-#         shipname2=temp
-#     elif result=="draw" or result=="d":
-#         result=fight_db.FIGHT_RESULT.DRAW
-#     else:
-#         print(f"Both player and Cosmoteer Design Tools picked {player_pick}; it is a draw!")
+    if(player_pick not in ships):
+        await interaction.response.send_message(f"Error:{player_pick} You need to pick between "+', '.join(list(ships.keys())))
+        return
+    player_win=False
+    computer_win=False
+    if(computer_pick in ships[player_pick]["wins"]):
+        player_win=True
+    elif(player_pick in ships[computer_pick]["wins"]):
+        computer_win=True
 
 
-# rps("dc spinner         ")
+    if player_win == True: # Display results to user
+        await interaction.response.send_message(f"{interaction.user.display_name} picked `{player_pick}` and Cosmoteer Design Tools picked `{computer_pick}`; {interaction.user.display_name} wins!")
+    elif computer_win:
+        await interaction.response.send_message(f"{interaction.user.display_name} picked `{player_pick}` and Cosmoteer Design Tools picked `{computer_pick}`; Cosmoteer Design Tools wins!")
+    else:
+        await interaction.response.send_message(f"{interaction.user.display_name} and Cosmoteer Design Tools picked `{player_pick}`; it is a draw!")
+
+@tree.command(name="db_add_fight", description='adds a new fight to the database')
+async def db_add_fight(interaction: discord.Interaction, shipname1: str, shipname2: str, result: str):
+    shipname1=shipname1.lower().strip()
+    shipname2=shipname2.lower().strip()
+    result=result.lower().strip()
+    if result=="win" or result=="w":
+        result=fight_db.FIGHT_RESULT.WIN
+    elif result=="lose" or result=="l":
+        result=fight_db.FIGHT_RESULT.WIN
+        temp=shipname1
+        shipname1=shipname2
+        shipname2=temp
+    elif result=="draw" or result=="d":
+        result=fight_db.FIGHT_RESULT.DRAW
+    else:
+        await interaction.response.send_message(f"Error: result must be 'win', 'lose' or 'draw'")
+        return
+
+    author=str(interaction.user.id)
+    author_name=interaction.user.display_name
+    try:
+        db.insert_fight(shipname1, shipname2, author, author_name, result)
+        winner_text=""
+        if result==fight_db.FIGHT_RESULT.WIN:
+            winner_text="the winner is "+shipname1
+        elif result==fight_db.FIGHT_RESULT.DRAW:
+            winner_text="it is a draw"
+        await interaction.response.send_message(f"In a fight between {shipname1} and {shipname2}, {winner_text}, according to {author_name}")
+    except Exception as e:
+        await interaction.response.send_message(f"Error:{e}")
+        return
+    
+@tree.command(name="db_add_ship", description='adds a new ship to the database')
+async def db_add_ship(interaction: discord.Interaction, shipname: str):
+    shipname=shipname.lower().strip()
+    author=str(interaction.user.id)
+    author_name=interaction.user.display_name
+    try:
+        db.add_ship(shipname, author, author_name)
+        await interaction.response.send_message(f"Ship {shipname} added to the database")
+    except Exception as e:
+        await interaction.response.send_message(f"Error:{e}")
+        return
+    
+@tree.command(name="db_remove_fight", description='removes a fight from the database')
+async def db_remove_fight(interaction: discord.Interaction, shipname1: str, shipname2: str):
+    shipname1=shipname1.lower().strip()
+    shipname2=shipname2.lower().strip()
+    author=str(interaction.user.id)
+    try:
+        db.remove_fight(shipname1, shipname2, author)
+        await interaction.response.send_message(f"Fight between {shipname1} and {shipname2} removed from the database")
+    except Exception as e:
+        await interaction.response.send_message(f"Error:{e}")
+        return
+    
+@tree.command(name="db_get_matchups", description='gets the matchups of a ship from the database')
+async def db_get_matchups(interaction: discord.Interaction, shipname: str):
+    shipname=shipname.lower().strip()
+    try:
+        wins, draws, losses=db.get_matchups(shipname)
+        text_wins="Wins:\n"
+        for ship in wins:
+            text_wins+=f"- **{ship}** : {', '.join(wins[ship])}\n"
+        text_draws="Draws:\n"
+        for ship in draws:
+            text_draws+=f"- **{ship}** : {', '.join(draws[ship])}\n"
+        text_losses="Losses:\n"
+        for ship in losses:
+            text_losses+=f"- **{ship}** : {', '.join(losses[ship])}\n"
+        text=f"Matchups for **{shipname}**\n"+text_wins+"\n"+text_draws+"\n"+text_losses
+        await interaction.response.send_message(text)
+    except Exception as e:
+        await interaction.response.send_message(f"Error:{str(traceback.format_exception_only(type(e), e)[0])}")
+        return
+
+    
+@tree.command(name="db_simulate_fight", description='simulates a fight between two ships')
+async def db_simulate_fight(interaction: discord.Interaction, shipname1: str, shipname2: str):
+    shipname1=shipname1.lower().strip()
+    shipname2=shipname2.lower().strip()
+    try:
+        result=db.simulate_fight(shipname1, shipname2)
+        people_win=result.get(fight_db.FIGHT_RESULT.WIN)
+        if people_win==None:
+            people_win=[]
+        people_draw=result.get(fight_db.FIGHT_RESULT.DRAW)
+        if people_draw==None:
+            people_draw=[]
+        people_lose=result.get(fight_db.FIGHT_RESULT.LOSE)
+        if people_lose==None:
+            people_lose=[]
+        text=f"In a fight between {shipname1} and {shipname2}, the results are:\n {len(people_win)} people think {shipname1} would win\n {len(people_draw)} people think it would be a draw\n {len(people_lose)} people think {shipname2} would win"
+        await interaction.response.send_message(text)
+    except Exception as e:
+        await interaction.response.send_message(f"Error:{e}")
+        return
+
+@tree.command(name="db_list_ships", description='lists all ships in the database')
+async def db_list_ships(interaction: discord.Interaction):
+    try:
+        ships=db.get_ships()
+        #sort the ships
+        ships.sort()
+        text="Ships in the database:\n"
+        for ship in ships:
+            text+=f"- {ship}\n"
+        await interaction.response.send_message(text)
+    except Exception as e:
+        await interaction.response.send_message(f"Error:{e}")
+        return
+    
+@tree.command(name="db_get_unknown_matchups", description='gets the unknown matchups of a ship from the database')
+async def db_get_unknown_matchups(interaction: discord.Interaction, shipname: str):
+    shipname=shipname.lower().strip()
+    try:
+        ships=db.get_unknown_matchups(shipname)
+        text="Unknown matchups for "+shipname+":\n"
+        for ship in ships:
+            text+=f"- {ship}\n"
+        await interaction.response.send_message(text)
+    except Exception as e:
+        await interaction.response.send_message(f"Error:{e}")
+        return
+
+@tree.command(name="db_export_csv", description='exports the database to a csv file')
+async def db_export_csv(interaction: discord.Interaction):
+    try:
+        db.export_csv("fight_database.csv")
+        # Create a file object for the CSV file
+        csv_file = discord.File("fight_database.csv", filename="fight_database.csv")
+        # Send the CSV file to the user
+        await interaction.response.send_message("Database exported to CSV file", file=csv_file)
+    except Exception as e:
+        await interaction.response.send_message(f"Error:{e}")
+        return
+    
+@tree.command(name="db_rename_ship", description='renames a ship in the database')
+async def db_rename_ship(interaction: discord.Interaction, old_name: str, new_name: str):
+    old_name=old_name.lower().strip()
+    new_name=new_name.lower().strip()
+    try:
+        author=str(interaction.user.id)
+        if author!="457210821773361152":
+            raise ValueError("Only LunastroD can rename ships!")
+        db.rename_ship(old_name, new_name)
+        await interaction.response.send_message(f"Ship {old_name} renamed to {new_name}")
+    except Exception as e:
+        await interaction.response.send_message(f"Error:{e}")
+        return
+    
+@tree.command(name="db_scoreboard", description='shows the scoreboard of the database')
+async def db_scoreboard(interaction: discord.Interaction):
+    try:
+        ships=db.get_ships()
+        scoreboard={}
+        for s in ships:
+            wins, draws, losses=db.get_matchups(s)
+            scoreboard[s]=[len(wins), len(draws), len(losses), len(wins)+len(draws)+len(losses)]
+        #sort the ships by number of wins
+        ships.sort(key=lambda x: scoreboard[x][0], reverse=True)
+        text="Scoreboard:\n"
+        for ship in ships:
+            text+=f"- **{ship}**: {scoreboard[ship][0]} {round(100*scoreboard[ship][0]/scoreboard[ship][3])}% win {scoreboard[ship][1]} {round(100*scoreboard[ship][1]/scoreboard[ship][3])}% draw {scoreboard[ship][2]} {round(100*scoreboard[ship][2]/scoreboard[ship][3])}% loss {scoreboard[ship][3]} total\n"
+        await interaction.response.send_message(text)
+    except Exception as e:
+        await interaction.response.send_message(f"Error:{e}")
+        return
 
 #client.run(os.getenv("DISCORDBOTAPI"))
-client.run(TOKEN)
+client.run(secret_token.token)

--- a/bot.py
+++ b/bot.py
@@ -22,8 +22,15 @@ API_URL = "https://cosmo-api-six.vercel.app/"
 API_NEW = "https://api.cosmoship.duckdns.org/"
 
 # UNCOMMENT EACH OF THE DB COMMANDS BEFORE SUBMITTING PULL REQUEST
+
+# BOT_PATH = "/home/astrod/Desktop/Bots/cosmoteer-com/"
+BOT_PATH = "/Users/nirav/Documents/GitHub/cosmoteer-com" # for the love of god please remove this one especially
+# db = fight_db.FightDB(db_name=BOT_PATH+"test.db")
+# #db = fight_db.FightDB()
+
 # db = fight_db.FightDB(db_name="/home/astrod/Desktop/Bots/cosmoteer-com/test.db")
 #db = fight_db.FightDB()
+
 
 
 intents = discord.Intents.default()
@@ -31,7 +38,7 @@ client = discord.Client(intents=intents)
 tree = app_commands.CommandTree(client)
 
 short_version_text="Made by LunastroD, Aug 2023 - Sep 2023"
-version_text=short_version_text+", for the Excelsior discord server and the Cosmoteer community :3\n- Check out the source code at <https://github.com/lunastrod/cosmoteer-com>\n- Thanks to Poney, Coconut Trebuchet and jun(0) for their help"
+version_text=short_version_text+", for the Excelsior discord server and the Cosmoteer community :3\n- Check out the source code at <https://github.com/lunastrod/cosmoteer-com>\n- Thanks to Poney, CoconutTrebuchet and jun(0) for their help"
 help_text=version_text+"""
 /ping: responds with the bot's latency
 
@@ -50,6 +57,34 @@ parameters:
 common questions:
 the bot considers the lateral thrust of each thruster
 the bot doesn't work with modded parts
+"""
+
+db_help_text = f"""/version: """+version_text+"""
+
+The Cosmoteer Design Tools bot has a database of every known multiplayer elimination archetype and their matchups that can be contributed to by anybody.
+Below is a list of commands that are used to access and contribute to the database.
+
+/help: Shows this message
+
+/db_list_ships: Lists every single ship type in the bot's archetype database. A handy reference for other db commands.
+
+/db_add_ships: Adds a new ship to the database.
+
+/db_rename_ship: Changes the existing name of a ship to a different specified one.
+
+/db_scoreboard: Shows the win/loss/draw ratio for each ship in the database based on matchups.
+
+/db_get_matchups: Lists each matchup (win, loss, draw) of a specified ship from the database.
+
+/db_get_unknown_matchups: Lists each matchup that has no votes from a specified ship from the database.
+
+/db_add_fight: Add a new matchup between 2 specified ship in the database.
+
+/db_remove_fight: Removes a matchup between 2 specified ship in the database.
+
+/db_simulate_fight: Simulates a fight between 2 specified ship, based on the listed matchup in the database.
+
+/db_export_csv: Exports the entire database to a .csv file.
 """
 
 @client.event
@@ -325,13 +360,14 @@ async def help(interaction: discord.Interaction):
     """
     print(dt.now(),"help command received")
     # Defer the initial response to prevent timeouts
-    await interaction.response.defer()
-    
-    # Generate the legend image for the command
-    #center_of_mass.draw_legend("legend.png")
-    
-    # Send the help text along with the legend image as a file
-    await interaction.followup.send(help_text, file=discord.File("legend.png"))
+    try:
+        await interaction.response.defer()
+        
+        # Send the help text along with the legend image as a file
+        await interaction.followup.send(help_text, file=discord.File(BOT_PATH+"legend.png"))
+    except Exception as e:
+        print(dt.now(),"Error:",e)
+        await interaction.followup.send("Error:"+str(e))
     print(dt.now(),"help command sent")
 
 @tree.command(name="elim_rps", description='play rock-paper-scissors, but with elimination archtypes!')

--- a/standalone_bot.py
+++ b/standalone_bot.py
@@ -31,6 +31,34 @@ help_text="""/version: """+version_text+"""
 
 - If you notice any mistakes on things like the total mass or the speed, ping LunastroD"""
 
+db_help_text = f"""/version: """+version_text+"""
+
+The Cosmoteer Design Tools bot has a database of every known multiplayer elimination archetype and their matchups that can be contributed to by anybody.
+Below is a list of commands that are used to access and contribute to the database.
+
+/help: Shows this message
+
+/db_list_ships: Lists every single ship type in the bot's archetype database. A handy reference for other db commands.
+
+/db_add_ships: Adds a new ship to the database.
+
+/db_rename_ship: Changes the existing name of a ship to a different specified one.
+
+/db_scoreboard: Shows the win/loss/draw ratio for each ship in the database based on matchups.
+
+/db_get_matchups: Lists each matchup (win, loss, draw) of a specified ship from the database.
+
+/db_get_unknown_matchups: Lists each matchup that has no votes from a specified ship from the database.
+
+/db_add_fight: Add a new matchup between 2 specified ship in the database.
+
+/db_remove_fight: Removes a matchup between 2 specified ship in the database.
+
+/db_simulate_fight: Simulates a fight between 2 specified ship, based on the listed matchup in the database.
+
+/db_export_csv: Exports the entire database to a .csv file.
+"""
+
 @client.event
 async def on_ready():
     await client.change_presence(activity=discord.Game(name="Cosmoteer (/help)"))
@@ -82,9 +110,12 @@ async def version(interaction: discord.Interaction):
     await interaction.response.send_message(version_text)
 
 @tree.command(name="help", description="shows the list of commands")
-async def help(interaction: discord.Interaction):
-    await interaction.response.defer()
-    center_of_mass.draw_legend("legend.png")
-    await interaction.followup.send(help_text,file=discord.File("legend.png"))
+async def help(interaction: discord.Interaction, list_database_commands: bool = False):
+    if not list_database_commands == True:
+        await interaction.response.defer()
+        center_of_mass.draw_legend("legend.png")
+        await interaction.followup.send(help_text,file=discord.File("legend.png"))
+    else:
+        await interaction.response.send_message(db_help_text)
 
 client.run(secret_token.token)

--- a/standalone_bot.py
+++ b/standalone_bot.py
@@ -1,3 +1,4 @@
+
 import discord
 from discord import app_commands
 import secret_token
@@ -30,34 +31,6 @@ help_text="""/version: """+version_text+"""
  - is the max speed exact? no, it's an approximation, assume ±1%, and it assumes your ship is balanced
 
 - If you notice any mistakes on things like the total mass or the speed, ping LunastroD"""
-
-db_help_text = f"""/version: """+version_text+"""
-
-The Cosmoteer Design Tools bot has a database of every known multiplayer elimination archetype and their matchups that can be contributed to by anybody.
-Below is a list of commands that are used to access and contribute to the database.
-
-/help: Shows this message
-
-/db_list_ships: Lists every single ship type in the bot's archetype database. A handy reference for other db commands.
-
-/db_add_ships: Adds a new ship to the database.
-
-/db_rename_ship: Changes the existing name of a ship to a different specified one.
-
-/db_scoreboard: Shows the win/loss/draw ratio for each ship in the database based on matchups.
-
-/db_get_matchups: Lists each matchup (win, loss, draw) of a specified ship from the database.
-
-/db_get_unknown_matchups: Lists each matchup that has no votes from a specified ship from the database.
-
-/db_add_fight: Add a new matchup between 2 specified ship in the database.
-
-/db_remove_fight: Removes a matchup between 2 specified ship in the database.
-
-/db_simulate_fight: Simulates a fight between 2 specified ship, based on the listed matchup in the database.
-
-/db_export_csv: Exports the entire database to a .csv file.
-"""
 
 @client.event
 async def on_ready():
@@ -110,12 +83,9 @@ async def version(interaction: discord.Interaction):
     await interaction.response.send_message(version_text)
 
 @tree.command(name="help", description="shows the list of commands")
-async def help(interaction: discord.Interaction, list_database_commands: bool = False):
-    if not list_database_commands == True:
-        await interaction.response.defer()
-        center_of_mass.draw_legend("legend.png")
-        await interaction.followup.send(help_text,file=discord.File("legend.png"))
-    else:
-        await interaction.response.send_message(db_help_text)
+async def help(interaction: discord.Interaction):
+    await interaction.response.defer()
+    center_of_mass.draw_legend("legend.png")
+    await interaction.followup.send(help_text,file=discord.File("legend.png"))
 
 client.run(secret_token.token)


### PR DESCRIPTION
/help now has a brand new non-required option called `show_db_commands` that is set to False by default. 

When it is changed to True, the command will instead post a list of each command related to the archtype matchup database that already exists in the Cosmoteer Design Tools bot. If left blank or set to False, /help instead posts the existing help text.