### PR TITLE
Debugged /db_list_ships

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -667,7 +667,8 @@ async def db_list_ships(interaction: discord.Interaction, filter_keyword: str=No
                 if filter_keyword in ship:
                     text+=f"- {ship}\n"
             else:
-                await send_long_message(interaction, text)
+                text+=f"- {ship}\n"
+        await send_long_message(interaction, text)
     except Exception as e:
         await interaction.response.send_message(f"Error:{e}")
         return


### PR DESCRIPTION
Previously, running /db_list_ships would iteratively print an entire message for each line in the command's output, as demonstrated in the screenshots sent on the Excelsior discord (message link [here](https://discord.com/channels/546229904488923141/1015816428881969162/1293380854999158868)).

I removed the line of code that was causing that problem, and now running /db_list_ships prints the code as normal.